### PR TITLE
support a shell-script option to avoid versioned egg references in rc scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,10 +13,16 @@ Releases
 0.3 (unreleased)
 ================
 
+- Added ``shell-script`` setting.  When true, shell scripts that refer
+  to a zdaemon script in the software installation are generated instead
+  of Python scripts in the rc directory.
+
+
 0.2 (2008-09-10)
 ================
 
 - Added support for the deployment recipe ``name`` option. 
+
 
 0.1 (2008-05-01)
 ================


### PR DESCRIPTION
(similar to zc.zodbrecipes)

This is needed to support updating the referenced software installation to with a new version of the zdaemon package in particular.
