### PR TITLE
Define builtins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ universal = 1
 
 [flake8]
 doctests = 1
+builtins = buildout, cat, system, write
 
 [check-manifest]
 ignore =

--- a/zc/zdaemonrecipe/tests.py
+++ b/zc/zdaemonrecipe/tests.py
@@ -66,7 +66,7 @@ There can be newlines in the program option:
         path /sample-buildout/parts/run/transcript.log
       </logfile>
     </eventlog>
-    """  # noqa: F821
+    """
 
 
 def setUp(test):


### PR DESCRIPTION
Flake8 complained about the usage of `buildout`, `system` and other
commands in docstrings.

Instead of using `noqa` comments, it is better to define those builtins
in the flake8 configuration section.

modified:   setup.cfg
modified:   zc/zdaemonrecipe/tests.py